### PR TITLE
fix(parser): normalize support-move-to-self as support-hold

### DIFF
--- a/src/agent/llm/llm-agent.test.ts
+++ b/src/agent/llm/llm-agent.test.ts
@@ -9,6 +9,7 @@ import {
   PhaseType,
   Power,
   RetreatSituation,
+  SupportOrder,
   Season,
   UnitType,
 } from '../../engine/types.js';
@@ -128,6 +129,22 @@ describe('parseOrders', () => {
       supportedUnit: 'par',
       destination: 'bur',
     });
+  });
+
+  it('normalizes support-move-to-self as support-hold', () => {
+    const state = makeState();
+    // LLMs sometimes emit destination === supportedUnit for support-hold
+    const text =
+      '```json\n[{"unit": "mar", "type": "support", "supportedUnit": "par", "destination": "par"}]\n```';
+    const orders = parseOrders(text, state, Power.France);
+    const marOrder = orders.find((o) => o.unit === 'mar');
+    expect(marOrder).toEqual({
+      type: OrderType.Support,
+      unit: 'mar',
+      supportedUnit: 'par',
+      // destination should be undefined (support-hold), not 'par'
+    });
+    expect((marOrder as SupportOrder).destination).toBeUndefined();
   });
 
   it('parses convoy orders', () => {

--- a/src/agent/llm/order-parser.ts
+++ b/src/agent/llm/order-parser.ts
@@ -148,11 +148,14 @@ export function parseOrders(text: string, state: GameState, power: Power): Order
         // Supported unit must exist
         if (!state.units.some((u) => u.province === supported)) break;
         const dest = resolveProvince(item.destination);
+        // If destination === supportedUnit, it's a support-hold (not a move-to-self)
+        // LLMs sometimes emit {"supportedUnit":"tri","destination":"tri"} for support-hold
+        const finalDest = dest === supported ? undefined : (dest ?? undefined);
         orders.set(unitProv, {
           type: OrderType.Support,
           unit: unitProv,
           supportedUnit: supported,
-          destination: dest ?? undefined,
+          destination: finalDest,
         });
         break;
       }


### PR DESCRIPTION
## Summary
- LLMs sometimes emit support orders with `destination === supportedUnit` (e.g. `{"supportedUnit":"tri","destination":"tri"}`) when they intend a support-hold
- The resolver's self-dislodgement check (Phase 6) correctly skips support-holds when `destination` is `undefined`, but treats `destination === supportedUnit` as a support-move, triggering "Cannot support dislodgement of own unit" incorrectly
- Normalizes `destination === supportedUnit` to `undefined` in the order parser so these orders are treated as support-holds

Reported in game notes for both Italy and Germany in the 2026-03-11 game.

## Test plan
- [x] Added test: `normalizes support-move-to-self as support-hold`
- [x] All 56 LLM agent tests pass
- [x] All 98 resolver tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Support orders that would target the same unit are now normalized to support-hold, preventing invalid self-support moves.

* **New Features**
  * Added a clearer, public order type and related typing improvements to increase robustness and clarity of order handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->