### PR TITLE
feat: add toggleable post-game press

### DIFF
--- a/src/game/lobby-manager.ts
+++ b/src/game/lobby-manager.ts
@@ -15,6 +15,7 @@ export interface LobbyConfig {
   pressDelayMax: number;
   agentConfig: GameConfig;
   autostart?: boolean;
+  postGamePress?: boolean;
 }
 
 export interface Lobby {

--- a/src/game/router.ts
+++ b/src/game/router.ts
@@ -245,6 +245,10 @@ export function createGameRouter(lobbyManager: LobbyManager) {
         }),
       )
       .mutation(({ ctx, input }) => {
+        const lobby = lobbyManager.getLobby(ctx.lobbyId);
+        if (lobby?.status === 'finished' && !lobby.config.postGamePress) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Post-game press is disabled' });
+        }
         const manager = resolveManager(lobbyManager, ctx.lobbyId);
         manager.sendMessage({
           from: ctx.power,


### PR DESCRIPTION
## Summary
- Adds `postGamePress` boolean to lobby config (default: disabled)
- When enabled, agents can continue sending messages after game ends
- When disabled, `sendMessage` returns FORBIDDEN after game over
- Enables post-game analysis, trash talk, and learning discussions

## Test plan
- [ ] Verify messages blocked after game over when postGamePress is false/undefined
- [ ] Verify messages allowed after game over when postGamePress is true
- [ ] Verify no impact on messaging during active game

🤖 Generated with [Claude Code](https://claude.com/claude-code)