### PR TITLE
feat: add getMessages endpoint

### DIFF
--- a/src/game/manager.ts
+++ b/src/game/manager.ts
@@ -189,6 +189,16 @@ export class GameManager {
     this.bus.onMessage(listener);
   }
 
+  /** Get all messages (for spectators/public view) */
+  getMessages(): Message[] {
+    return this.bus.getMessages();
+  }
+
+  /** Get messages visible to a specific power (includes private messages to them) */
+  getMessagesFor(power: Power): Message[] {
+    return this.bus.getMessagesFor(power);
+  }
+
   getTurnHistory(): TurnRecord[] {
     return this.turnHistory;
   }

--- a/src/game/router.test.ts
+++ b/src/game/router.test.ts
@@ -125,6 +125,14 @@ describe('game router wire format', () => {
     });
   });
 
+  describe('getMessages', () => {
+    it('returns empty array when no messages have been sent', async () => {
+      const { caller, lobbyId } = setupTestGame();
+      const messages = await caller.game.getMessages({ lobbyId });
+      expect(messages).toEqual([]);
+    });
+  });
+
   describe('getRules', () => {
     it('returns rules as markdown string with game config substituted', async () => {
       const { caller, lobbyId } = setupTestGame();

--- a/src/game/router.ts
+++ b/src/game/router.ts
@@ -212,6 +212,19 @@ export function createGameRouter(lobbyManager: LobbyManager) {
       return manager.getActivePowers();
     }),
 
+    getMessages: publicProcedure.input(lobbyIdInput).query(({ input, ctx }) => {
+      const manager = resolveManager(lobbyManager, input.lobbyId);
+      // Authenticated: see messages addressed to this power (private + global)
+      if (ctx.token) {
+        const identity = lobbyManager.validateToken(ctx.token);
+        if (identity && 'power' in identity) {
+          return manager.getMessagesFor(identity.power as Power);
+        }
+      }
+      // Spectator: only global messages
+      return manager.getMessages().filter((m) => m.to === 'Global');
+    }),
+
     // Mutations
     submitOrders: playerProcedure
       .input(z.object({ orders: z.array(orderSchema) }))


### PR DESCRIPTION
## Summary
- Adds `getMessages` tRPC query endpoint for retrieving full message history
- Auth-aware: authenticated agents see private + global messages, spectators see only global
- Enables reconnect catch-up and pre-move diplomatic record review

## Test plan
- [ ] Verify spectators only see Global messages
- [ ] Verify authenticated agents see their private messages
- [ ] Verify empty array returned when no messages exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)