### PR TITLE
feat: add getResult endpoint

### DIFF
--- a/src/game/lobby-manager.ts
+++ b/src/game/lobby-manager.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 
 import type { GameConfig } from '../agent/llm/config.js';
 import { Power } from '../engine/types.js';
-import { GameManager } from './manager.js';
+import { GameManager, type GameResult } from './manager.js';
 
 export interface LobbyConfig {
   name: string;
@@ -25,6 +25,7 @@ export interface Lobby {
   creatorToken: string;
   seats: Map<Power, string>;
   manager: GameManager | null;
+  result: GameResult | null;
 }
 
 export class LobbyManager {
@@ -48,6 +49,7 @@ export class LobbyManager {
       creatorToken,
       seats: new Map(),
       manager: null,
+      result: null,
     };
     this.lobbies.set(id, lobby);
     return { lobbyId: id, creatorToken };
@@ -156,10 +158,11 @@ export class LobbyManager {
     return null;
   }
 
-  finishLobby(id: string): void {
+  finishLobby(id: string, result?: GameResult): void {
     const lobby = this.lobbies.get(id);
     if (!lobby) return;
     lobby.status = 'finished';
+    if (result) lobby.result = result;
   }
 
   deleteLobby(id: string): void {

--- a/src/game/router.test.ts
+++ b/src/game/router.test.ts
@@ -125,6 +125,14 @@ describe('game router wire format', () => {
     });
   });
 
+  describe('getResult', () => {
+    it('returns null when game is still in progress', async () => {
+      const { caller, lobbyId } = setupTestGame();
+      const result = await caller.game.getResult({ lobbyId });
+      expect(result).toBeNull();
+    });
+  });
+
   describe('getRules', () => {
     it('returns rules as markdown string with game config substituted', async () => {
       const { caller, lobbyId } = setupTestGame();

--- a/src/game/router.ts
+++ b/src/game/router.ts
@@ -212,6 +212,22 @@ export function createGameRouter(lobbyManager: LobbyManager) {
       return manager.getActivePowers();
     }),
 
+    getResult: publicProcedure.input(lobbyIdInput).query(({ input }) => {
+      const lobby = lobbyManager.getLobby(input.lobbyId);
+      if (!lobby) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: `Lobby ${input.lobbyId} not found` });
+      }
+      if (lobby.status !== 'finished' || !lobby.result) {
+        return null;
+      }
+      return {
+        winner: lobby.result.winner,
+        year: lobby.result.year,
+        supplyCenters: Object.fromEntries(lobby.result.supplyCenters),
+        eliminatedPowers: lobby.result.eliminatedPowers,
+      };
+    }),
+
     // Mutations
     submitOrders: playerProcedure
       .input(z.object({ orders: z.array(orderSchema) }))

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -222,7 +222,7 @@ function startServer(): void {
             supplyCenters: Object.fromEntries(result.supplyCenters),
           },
         });
-        lobbyManager.finishLobby(id);
+        lobbyManager.finishLobby(id, result);
         cleanupLobbyRuntime(id);
         logger.info(
           result.winner


### PR DESCRIPTION
## Summary
- Adds `getResult` tRPC query returning game outcome (winner, year, SC ownership, eliminated powers)
- Lobby now stores `GameResult` when game finishes via `finishLobby(id, result)`
- Returns `null` while game is in progress

## Test plan
- [ ] Verify null returned during active game
- [ ] Verify result returned after game ends (winner, year, SCs, eliminations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)