### PR TITLE
feat: agent strategic context, plan persistence, and prompt improvements

### DIFF
--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -30,6 +30,48 @@ Verify reachability: `curl -s http://host.docker.internal:11434/api/tags`
   - Pass a different model name as an argument: `.devcontainer/start-ollama.sh qwen2.5:3b`
 - Verify Ollama is reachable: `curl -s http://ollama:11434/api/tags`
 
+## Configuration Gathering
+
+**Before any setup steps**, gather the following configuration values. Extract from the user's prompt where provided. For anything missing or ambiguous, use `AskUserQuestion` to prompt the user — do NOT guess at values that meaningfully affect game behavior.
+
+### Values to collect
+
+| Setting | Prompt question | Default | Notes |
+|---------|----------------|---------|-------|
+| **Model** | "Which model should the agents use?" | (none — must be provided or chosen from list) | Show available models from Ollama preflight check |
+| **Ollama host** | "Should agents use host Ollama or Docker Ollama?" | host (if reachable) | Determine automatically via reachability; only ask if ambiguous |
+| **Max years** | "How many years should the game run, or should it run until the win condition is met?" | (omit — run until win) | Omit from lobby creation to run indefinitely; "100 years" → 100; "quick test" → 2 |
+| **Victory threshold** | "How many supply centers are needed to win?" | 18 | Standard Diplomacy is 18; max 34 (all SCs) |
+| **Allow draws** | "Should powers be able to propose and accept draws?" | true | Set false to force a decisive winner |
+| **Fast adjudication** | "Should the engine advance as soon as all agents submit, without waiting for the phase duration?" | true | "fast adjudication" or "fast" in prompt → true |
+| **Phase duration (ms)** | "What is the maximum time each phase should last?" | 0 (no limit) | With fast adjudication: phase ends when all submit OR timer fires, whichever is first. Without: phase always waits the full duration. e.g. "60 minute phases" → 3600000 |
+| **LLM concurrency** | "How many agents can call Ollama simultaneously? (should match OLLAMA_NUM_PARALLEL on host)" | 1 | If user mentions GPU/VRAM or parallel, ask for this explicitly |
+| **Remote timeout (ms)** | "How long should the server wait for agent submissions per phase?" | 600000 | 10 min default; increase for slow models or long games |
+| **LLM request timeout (ms)** | "Per-request timeout for LLM calls?" | 900000 | 15 min default for safety |
+| **Monitor interval** | "How often should the referee check in on the game?" | half the phase duration, or 10m if no phase cap | e.g. 60 min phases → 30m check-ins; no cap → 10m. User can override. Used for `/loop` interval in step 8. |
+
+### Ambiguity rules
+
+- If user specifies a model name not exactly matching an available model, show the available list and ask which to use (do not silently substitute).
+- If the user does not mention a year limit, omit `maxYears` entirely — the game runs until victory or a draw.
+- If user says "100 years", use `maxYears: 100`. If they say "quick test", use `maxYears: 2`.
+- If user says "fast adjudication" or "fast", use `fastAdjudication: true`.
+- If the user specifies a phase duration (e.g. "60 minute phases"), set `phaseDelayMs` accordingly. These two settings compose: with both set, the phase ends when all agents submit OR when the timer fires — whichever comes first.
+- If the user provides `LLM_CONCURRENCY` or mentions parallel requests, use that value.
+- If Ollama is reachable at host.docker.internal, default to host config; if only docker is reachable, default to docker config; if both or neither, ask.
+
+### Example extraction
+
+> "run a 100 year integration test, using ollama qwen2.5:7b - with fast adjudication"
+
+→ maxYears: 100, model: qwen2.5:7b (verify against available list), fastAdjudication: true, all other values → defaults. No questions needed.
+
+> "run an integration test using ollama qwen2.5:3b until someone wins"
+
+→ maxYears: omitted (run until win condition), model: qwen2.5:3b, fastAdjudication: true (default), no questions needed.
+
+---
+
 ## Setup
 
 ### 1. Build the project
@@ -129,12 +171,19 @@ You MUST run this via the Bash tool — these are native remote agent processes,
 
 ### 8. Monitor as referee using /loop
 
-After all agents are connected, invoke the `/loop` skill to set up recurring monitoring. Set the interval to roughly **half the observed phase length** — watch the first phase complete to gauge timing, then set the loop accordingly.
+After all agents are connected, invoke the `/loop` skill to set up recurring monitoring. Use the **monitor interval** from the configuration gathering step.
 
-Use the `/loop` skill with a prompt like:
+**IMPORTANT:** NEVER cancel the monitoring loop unless the user explicitly asks you to. Games may appear stalled between checks but are still progressing — phases can take a long time with slow models. Only the user should decide when to stop monitoring.
+
+**Default monitor interval logic:**
+- If phase duration is set: use **half** the phase duration (e.g. 60 min phases → `30m`)
+- If no phase duration cap: use **`10m`**
+- If the user specified a custom interval, use that instead
+
+Use the `/loop` skill with the computed interval:
 
 ```text
-/loop <interval> Check game <LOBBY_ID>: curl game state from localhost:3000, report phase/year, SC counts per power, unit positions, check lobby status for game completion. If game is finished, report final results and stop. Append notable events to game-notes/REFEREE_NOTES_<LOBBY_ID>.md.
+/loop <monitor-interval> Check game <LOBBY_ID>: curl game state from localhost:3000, report phase/year, SC counts per power, unit positions, check lobby status for game completion. If game is finished, report final results and stop. Append notable events to game-notes/REFEREE_NOTES_<LOBBY_ID>.md.
 ```
 
 You can also poll manually at any time:

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -112,7 +112,7 @@ If the desired model is not listed, ask the user which model to use from the ava
 npx tsx src/ui/server.ts &
 SERVER_PID=$!
 # Wait for server to be ready (no /health endpoint — check root)
-until curl -sf http://localhost:3000/ > /dev/null 2>&1; do sleep 1; done
+until curl -sf http://localhost:3000/api/health > /dev/null 2>&1; do sleep 1; done
 echo "Server ready (PID $SERVER_PID)"
 ```
 

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -69,8 +69,8 @@ If the desired model is not listed, ask the user which model to use from the ava
 ```bash
 npx tsx src/ui/server.ts &
 SERVER_PID=$!
-# Wait for server to be ready
-until curl -sf http://localhost:3000/health > /dev/null 2>&1; do sleep 1; done
+# Wait for server to be ready (no /health endpoint — check root)
+until curl -sf http://localhost:3000/ > /dev/null 2>&1; do sleep 1; done
 echo "Server ready (PID $SERVER_PID)"
 ```
 
@@ -98,7 +98,7 @@ Create `game-notes/REFEREE_NOTES_{lobbyId}.md` with setup info (lobby ID, model,
 
 ### 7. Launch 7 Ollama-powered agents
 
-Launch each power as a background remote agent process. All agents launch simultaneously — Ollama queues requests naturally. PIDs are saved to a file for reliable cleanup later.
+Launch each power as a background remote agent process. A cross-process file semaphore (`FileSemaphore` in `src/agent/llm/semaphore.ts`) limits concurrent Ollama requests to avoid undici's 5-minute `headersTimeout` (see Troubleshooting). PIDs are saved for cleanup.
 
 ```bash
 POWERS=(England France Germany Italy Austria Russia Turkey)
@@ -111,8 +111,14 @@ PID_FILE="game-notes/agent-pids.txt"
 ## Option B (docker Ollama): DIPLOMAICY_CONFIG=diplomaicy.config.ollama-docker.json
 DIPLOMAICY_CONFIG=diplomaicy.config.ollama-host.json
 
+## LLM_CONCURRENCY controls how many agents can call Ollama simultaneously.
+## Set this to match OLLAMA_NUM_PARALLEL on the host (default: 1).
+## LLM_REQUEST_TIMEOUT_MS is the per-request timeout (default: 600s / 10 min).
+
 for power in "${POWERS[@]}"; do
   DIPLOMAICY_CONFIG="$DIPLOMAICY_CONFIG" \
+  LLM_CONCURRENCY=2 \
+  LLM_REQUEST_TIMEOUT_MS=900000 \
   npx tsx integration-test/run-with-notes.ts --power "$power" --lobby "$LOBBY_ID" --type llm --notes-dir "game-notes" > "game-notes/${power}.log" 2>&1 &
   echo $! >> "$PID_FILE"
 done
@@ -182,6 +188,9 @@ if [ -n "$SERVER_PID" ]; then
   kill "$SERVER_PID" 2>/dev/null
   echo "Server stopped."
 fi
+
+# Clean up file semaphore locks
+rm -rf /tmp/diplomaicy-llm-locks
 ```
 
 ### Alternative: Automated Script
@@ -198,43 +207,34 @@ If Ollama is running somewhere other than the devcontainer service:
 LLM_BASE_URL=http://localhost:11434/v1  # or wherever Ollama is
 ```
 
-### Parallel Ollama Slots
+### Concurrency: LLM_CONCURRENCY and OLLAMA_NUM_PARALLEL
 
-By default, Ollama processes requests sequentially (`OLLAMA_NUM_PARALLEL=1`). With 7 agents each making 3-5 LLM calls per phase, this creates a bottleneck where phases take 10-15 minutes to resolve.
+Node.js `fetch` uses undici, which has a hardcoded 5-minute `headersTimeout`. When 7 agents all queue requests on Ollama simultaneously, later requests wait >5 min for a slot, and undici kills the connection — Ollama logs this as a 500 error.
 
-Setting `OLLAMA_NUM_PARALLEL` allows multiple agents to query simultaneously:
+**The fix:** A cross-process file semaphore (`FileSemaphore` in `src/agent/llm/semaphore.ts`) limits how many agents can call Ollama at once. Set via the `LLM_CONCURRENCY` env var (default: 1). Lock files live in `/tmp/diplomaicy-llm-locks/` and are cleaned up automatically (stale PID detection on startup, removal on process exit/SIGTERM).
+
+**`LLM_CONCURRENCY` should match `OLLAMA_NUM_PARALLEL`** on the host. If Ollama can handle 2 parallel requests, set both to 2.
 
 ```bash
-# On the host machine (stop existing Ollama first):
-OLLAMA_NUM_PARALLEL=3 ollama serve
+# On the host machine:
+OLLAMA_NUM_PARALLEL=2 ollama serve
+
+# When launching agents (inside devcontainer):
+LLM_CONCURRENCY=2
 ```
 
-**VRAM budget** (qwen2.5:14b Q4_K_M uses ~9.3GB base):
-- **16GB unified memory (M2 Pro etc.):** `N=2` safe, `N=3` tight but workable
+**VRAM budget** (each parallel slot adds ~0.5-1GB for KV cache):
+
+- **16GB unified memory (M2 Pro etc.):** `N=2` safe, `N=3` tight
 - **32GB:** `N=4-5` comfortably
-- **48GB+:** `N=7` (one slot per agent)
-
-Each parallel slot adds ~0.5-1GB for KV cache. If you see performance degrade or swapping, reduce `N`.
-
-**Alternative:** Use a smaller model (`qwen2.5:7b` at ~4.7GB) with higher parallelism — e.g., `N=3` with 7b on 16GB gives ~6x speedup vs `N=1` with 14b.
-
-If Ollama is managed by Homebrew:
-```bash
-brew services stop ollama
-OLLAMA_NUM_PARALLEL=3 ollama serve   # runs in foreground
-```
-
-Or via launchctl:
-```bash
-launchctl setenv OLLAMA_NUM_PARALLEL 3
-brew services restart ollama
-```
+- **48GB+:** `N=7` (one slot per agent — no semaphore needed)
 
 ### Timeouts
 
-- `remoteTimeoutMs` in lobby creation controls how long the server waits for agent submissions
-- The default of 600000 (10 min) is generous; for faster models you can decrease it (e.g. `"remoteTimeoutMs": 180000` for 3 min)
-- `PHASE_DELAY` env var on the server controls the minimum delay between engine phases (default 10 minutes). With `fastAdjudication: true`, the engine advances as soon as all agents submit, so `PHASE_DELAY` only matters if agents are faster than the delay
+- **`LLM_REQUEST_TIMEOUT_MS`** — Per-request timeout on the agent side (default: 600s / 10 min). Set to 900000 (15 min) for slower models or large prompts.
+- **`remoteTimeoutMs`** — In lobby creation, controls how long the server waits for agent submissions per phase.
+- **`keep_alive`** — Sent in every LLM request body (hardcoded to `60m`). Tells Ollama to keep the model loaded for 60 minutes between requests instead of the default 5 minutes. This prevents unnecessary model reloads during long games.
+- **`PHASE_DELAY`** — Server env var for minimum delay between engine phases. With `fastAdjudication: true`, the engine advances as soon as all agents submit, so this only matters if agents are faster than the delay.
 
 ## Monitoring
 
@@ -251,6 +251,7 @@ curl -s http://ollama:11434/api/ps | python3 -m json.tool
 ```
 
 Common issues to watch for:
+
 - `"aborting completion request due to client closing the connection"` — LLM client timeout too short for inference. The default is 600s (10 min). Set `LLM_REQUEST_TIMEOUT_MS` env var to adjust
 - `size_vram: 0` in `api/ps` output — model is running on CPU only, expect slow inference. Use a smaller model (3B or 0.5B)
 - OOM kills — model too large for available memory
@@ -277,6 +278,10 @@ Review these to understand agent behavior and identify prompt improvements.
 **"Ollama not reachable"** — Ollama doesn't start by default. Run `.devcontainer/start-ollama.sh` to start it.
 
 **"model not found"** — Pull the model first: `curl http://ollama:11434/api/pull -d '{"name":"qwen2.5:7b"}'`
+
+**Ollama 500 errors at exactly 5 minutes** — This is Node.js undici's `headersTimeout` (5 min default) killing connections when Ollama takes too long to respond. The fix is the `FileSemaphore` + `LLM_CONCURRENCY` env var, which queues requests in-process instead of on Ollama's side. Ensure `LLM_CONCURRENCY` matches `OLLAMA_NUM_PARALLEL`. If you see `UND_ERR_HEADERS_TIMEOUT` in agent logs, this is the cause.
+
+**"Lobby is not accepting players"** — Agent crashed and tried to rejoin a running game. The `run-with-notes.ts` script has no rejoin path — you must start a fresh lobby. Kill everything, `rm diplomaicy.db`, and restart.
 
 **Agents hang** — The model may be too slow. Try a smaller model or increase timeouts.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ By AI, for AI.
 
 Agentic Diplomacy. Ever wanted to see Europe torn asunder by robots? diplomAIcy gets you closer than ever!
 
-A full implementation of the classic board game [Diplomacy](https://en.wikipedia.org/wiki/Diplomacy_(game)) designed to be played entirely by AI agents, with a read-only spectator UI so humans can watch the chaos unfold.
+A full implementation of the classic board game [Diplomacy](<https://en.wikipedia.org/wiki/Diplomacy_(game)>) designed to be played entirely by AI agents, with a read-only spectator UI so humans can watch the chaos unfold.
 
 ## Features
 
@@ -84,24 +84,26 @@ Per-power overrides can be added under a `"powers"` key (see `diplomaicy.config.
 
 ### Environment variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `PORT` | `3000` | Server port |
-| `MAX_YEARS` | `5` | Game length in years |
-| `PHASE_DELAY` | `5000` | Delay between phases (ms) |
-| `REMOTE_TIMEOUT` | `120000` | Timeout for remote agent responses (ms) |
-| `DB_PATH` | `diplomaicy.db` | SQLite database path |
-| `ANTHROPIC_API_KEY` | — | API key for Anthropic models |
+| Variable                 | Default         | Description                                                                                                   |
+| ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `PORT`                   | `3000`          | Server port                                                                                                   |
+| `MAX_YEARS`              | `5`             | Game length in years                                                                                          |
+| `PHASE_DELAY`            | `5000`          | Delay between phases (ms)                                                                                     |
+| `REMOTE_TIMEOUT`         | `120000`        | Timeout for remote agent responses (ms)                                                                       |
+| `DB_PATH`                | `diplomaicy.db` | SQLite database path                                                                                          |
+| `ANTHROPIC_API_KEY`      | —               | API key for Anthropic models                                                                                  |
+| `LLM_CONCURRENCY`        | `1`             | Max concurrent LLM requests (increase if running multiple inference slots) - used for local integration tests |
+| `LLM_REQUEST_TIMEOUT_MS` | `600000`        | Per-request timeout for LLM API calls (ms)                                                                    |
 
 For remote agents, these additional env vars apply:
 
-| Variable | Description |
-|---|---|
-| `LLM_PROVIDER` | LLM provider (`anthropic`, etc.) |
-| `LLM_BASE_URL` | API base URL |
-| `LLM_API_KEY` | API key for the agent process |
-| `LLM_MODEL` | Model identifier |
-| `GAME_SERVER` | tRPC server URL (default `http://localhost:3000/trpc`) |
+| Variable       | Description                                            |
+| -------------- | ------------------------------------------------------ |
+| `LLM_PROVIDER` | LLM provider (`anthropic`, etc.)                       |
+| `LLM_BASE_URL` | API base URL                                           |
+| `LLM_API_KEY`  | API key for the agent process                          |
+| `LLM_MODEL`    | Model identifier                                       |
+| `GAME_SERVER`  | tRPC server URL (default `http://localhost:3000/trpc`) |
 
 ## Development
 

--- a/diplomaicy.config.ollama-host.json
+++ b/diplomaicy.config.ollama-host.json
@@ -4,7 +4,7 @@
     "provider": "openai",
     "baseUrl": "http://host.docker.internal:11434/v1",
     "apiKey": "ollama",
-    "model": "qwen2.5:3b",
+    "model": "qwen3:8b",
     "temperature": 0.7,
     "maxTokens": 2048,
     "numCtx": 8192

--- a/diplomaicy.config.ollama-host.json
+++ b/diplomaicy.config.ollama-host.json
@@ -4,7 +4,7 @@
     "provider": "openai",
     "baseUrl": "http://host.docker.internal:11434/v1",
     "apiKey": "ollama",
-    "model": "qwen2.5:3b",
+    "model": "qwen3.5:9b",
     "temperature": 0.7,
     "maxTokens": 2048,
     "numCtx": 8192

--- a/diplomaicy.config.ollama-host.json
+++ b/diplomaicy.config.ollama-host.json
@@ -4,7 +4,7 @@
     "provider": "openai",
     "baseUrl": "http://host.docker.internal:11434/v1",
     "apiKey": "ollama",
-    "model": "qwen3:8b",
+    "model": "qwen2.5:3b",
     "temperature": 0.7,
     "maxTokens": 2048,
     "numCtx": 8192

--- a/diplomaicy.config.ollama-host.json
+++ b/diplomaicy.config.ollama-host.json
@@ -4,7 +4,7 @@
     "provider": "openai",
     "baseUrl": "http://host.docker.internal:11434/v1",
     "apiKey": "ollama",
-    "model": "qwen3.5:9b",
+    "model": "qwen3:8b",
     "temperature": 0.7,
     "maxTokens": 2048,
     "numCtx": 8192

--- a/integration-test/run-with-notes.ts
+++ b/integration-test/run-with-notes.ts
@@ -145,7 +145,7 @@ async function main() {
     console.log(
       `Starting tool-calling agent with notes for ${power} (${cfg.provider ?? 'openai'}/${cfg.model}), notes → ${notesDir}/${lobbyId}/${power}.md`,
     );
-    const { unsubscribe } = await connectToolAgent(trpcClient, llmClient, power, lobbyId);
+    const { unsubscribe } = await connectToolAgent(trpcClient, llmClient, power, lobbyId, notesDir);
 
     const shutdown = () => {
       unsubscribe();

--- a/src/agent/llm/llm-client.ts
+++ b/src/agent/llm/llm-client.ts
@@ -44,6 +44,7 @@ export interface LLMClientConfig {
 }
 
 import { logger } from '../../util/logger';
+import { llmSemaphore } from './semaphore';
 
 export class OpenAICompatibleClient implements LLMClient {
   private config: Required<Omit<LLMClientConfig, 'numCtx'>>;
@@ -73,6 +74,7 @@ export class OpenAICompatibleClient implements LLMClient {
         await new Promise((r) => setTimeout(r, baseDelay + jitter));
       }
 
+      await llmSemaphore.acquire();
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
       try {
@@ -115,6 +117,7 @@ export class OpenAICompatibleClient implements LLMClient {
         continue;
       } finally {
         clearTimeout(timeout);
+        llmSemaphore.release();
       }
     }
 
@@ -128,6 +131,7 @@ export class OpenAICompatibleClient implements LLMClient {
       messages,
       temperature: this.config.temperature,
       max_tokens: this.config.maxTokens,
+      keep_alive: '60m',
     };
 
     // Ollama supports num_ctx via options to control context window size
@@ -163,6 +167,7 @@ export class OpenAICompatibleClient implements LLMClient {
         messages: conversation,
         temperature: this.config.temperature,
         max_tokens: this.config.maxTokens,
+        keep_alive: '60m',
       };
 
       if (tools.length > 0) {

--- a/src/agent/llm/prompts.test.ts
+++ b/src/agent/llm/prompts.test.ts
@@ -31,12 +31,12 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
   return {
     phase: { year: 1901, season: Season.Spring, type: PhaseType.Orders },
     units: [
-      { power: Power.England, type: UnitType.Army, province: 'lon', coast: null },
-      { power: Power.England, type: UnitType.Fleet, province: 'edi', coast: null },
-      { power: Power.England, type: UnitType.Fleet, province: 'lvp', coast: null },
-      { power: Power.France, type: UnitType.Army, province: 'par', coast: null },
-      { power: Power.France, type: UnitType.Army, province: 'mar', coast: null },
-      { power: Power.France, type: UnitType.Fleet, province: 'bre', coast: null },
+      { power: Power.England, type: UnitType.Army, province: 'lon', coast: undefined },
+      { power: Power.England, type: UnitType.Fleet, province: 'edi', coast: undefined },
+      { power: Power.England, type: UnitType.Fleet, province: 'lvp', coast: undefined },
+      { power: Power.France, type: UnitType.Army, province: 'par', coast: undefined },
+      { power: Power.France, type: UnitType.Army, province: 'mar', coast: undefined },
+      { power: Power.France, type: UnitType.Fleet, province: 'bre', coast: undefined },
     ],
     supplyCenters,
     orderHistory: [],
@@ -80,8 +80,8 @@ describe('buildStrategicSummary', () => {
   it('identifies neighboring enemy units', () => {
     const state = makeState({
       units: [
-        { power: Power.England, type: UnitType.Fleet, province: 'lon', coast: null },
-        { power: Power.France, type: UnitType.Fleet, province: 'eng', coast: null },
+        { power: Power.England, type: UnitType.Fleet, province: 'lon', coast: undefined },
+        { power: Power.France, type: UnitType.Fleet, province: 'eng', coast: undefined },
       ],
     });
     const summary = buildStrategicSummary(state, Power.England);
@@ -98,8 +98,8 @@ describe('buildStrategicSummary', () => {
     const state = makeState({
       supplyCenters,
       units: [
-        { power: Power.England, type: UnitType.Fleet, province: 'lon', coast: null },
-        { power: Power.England, type: UnitType.Fleet, province: 'edi', coast: null },
+        { power: Power.England, type: UnitType.Fleet, province: 'lon', coast: undefined },
+        { power: Power.England, type: UnitType.Fleet, province: 'edi', coast: undefined },
       ],
     });
     const summary = buildStrategicSummary(state, Power.England);

--- a/src/agent/llm/prompts.test.ts
+++ b/src/agent/llm/prompts.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { GameState, PhaseType, Power, Season, UnitType } from '../../engine/types';
+import { buildStrategicSummary, extractPlanBlock } from './prompts';
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  const supplyCenters = new Map<string, Power>([
+    ['lon', Power.England],
+    ['edi', Power.England],
+    ['lvp', Power.England],
+    ['par', Power.France],
+    ['bre', Power.France],
+    ['mar', Power.France],
+    ['ber', Power.Germany],
+    ['mun', Power.Germany],
+    ['kie', Power.Germany],
+    ['rom', Power.Italy],
+    ['nap', Power.Italy],
+    ['ven', Power.Italy],
+    ['vie', Power.Austria],
+    ['bud', Power.Austria],
+    ['tri', Power.Austria],
+    ['mos', Power.Russia],
+    ['war', Power.Russia],
+    ['stp', Power.Russia],
+    ['sev', Power.Russia],
+    ['con', Power.Turkey],
+    ['ank', Power.Turkey],
+    ['smy', Power.Turkey],
+  ]);
+  return {
+    phase: { year: 1901, season: Season.Spring, type: PhaseType.Orders },
+    units: [
+      { power: Power.England, type: UnitType.Army, province: 'lon', coast: null },
+      { power: Power.England, type: UnitType.Fleet, province: 'edi', coast: null },
+      { power: Power.England, type: UnitType.Fleet, province: 'lvp', coast: null },
+      { power: Power.France, type: UnitType.Army, province: 'par', coast: null },
+      { power: Power.France, type: UnitType.Army, province: 'mar', coast: null },
+      { power: Power.France, type: UnitType.Fleet, province: 'bre', coast: null },
+    ],
+    supplyCenters,
+    orderHistory: [],
+    retreatSituations: [],
+    ...overrides,
+  };
+}
+
+describe('buildStrategicSummary', () => {
+  it('shows power rankings sorted by SC count', () => {
+    const state = makeState();
+    const summary = buildStrategicSummary(state, Power.England);
+    expect(summary).toContain('Russia: 4 SCs');
+    expect(summary).toContain('England: 3 SCs');
+    // Russia should appear before England (more SCs)
+    expect(summary.indexOf('Russia')).toBeLessThan(summary.indexOf('England'));
+  });
+
+  it('shows trend arrows for SC changes', () => {
+    const supplyCenters = new Map<string, Power>([
+      ['lon', Power.England],
+      ['edi', Power.England],
+      ['lvp', Power.England],
+      ['bel', Power.England],
+    ]);
+    const state = makeState({ supplyCenters });
+    const summary = buildStrategicSummary(state, Power.England);
+    expect(summary).toMatch(/England.*\+1/);
+  });
+
+  it('lists neutral supply centers', () => {
+    const state = makeState();
+    const summary = buildStrategicSummary(state, Power.England);
+    expect(summary).toContain('NEUTRAL SUPPLY CENTERS');
+    expect(summary).toContain('bel');
+    expect(summary).toContain('hol');
+    expect(summary).toContain('den');
+    expect(summary).not.toMatch(/NEUTRAL.*lon/);
+  });
+
+  it('identifies neighboring enemy units', () => {
+    const state = makeState({
+      units: [
+        { power: Power.England, type: UnitType.Fleet, province: 'lon', coast: null },
+        { power: Power.France, type: UnitType.Fleet, province: 'eng', coast: null },
+      ],
+    });
+    const summary = buildStrategicSummary(state, Power.England);
+    expect(summary).toContain('France');
+    expect(summary).toContain('eng');
+  });
+
+  it('shows lost home centers', () => {
+    const supplyCenters = new Map<string, Power>([
+      ['lon', Power.England],
+      ['edi', Power.England],
+      ['lvp', Power.France],
+    ]);
+    const state = makeState({
+      supplyCenters,
+      units: [
+        { power: Power.England, type: UnitType.Fleet, province: 'lon', coast: null },
+        { power: Power.England, type: UnitType.Fleet, province: 'edi', coast: null },
+      ],
+    });
+    const summary = buildStrategicSummary(state, Power.England);
+    expect(summary).toContain('lvp');
+    expect(summary).toMatch(/lost/i);
+  });
+});
+
+describe('extractPlanBlock', () => {
+  it('extracts plan from response with plan fence', () => {
+    const response =
+      'I will attack.\n\n```plan\nGOAL: Take Belgium\nALLIES: France\nENEMIES: Germany\nNEXT: A yor → bel\n```\n\nDone.';
+    const result = extractPlanBlock(response);
+    expect(result.plan).toContain('GOAL: Take Belgium');
+    expect(result.plan).toContain('ALLIES: France');
+    expect(result.cleaned).not.toContain('```plan');
+    expect(result.cleaned).toContain('I will attack.');
+  });
+
+  it('returns null plan when no plan block', () => {
+    const response = 'Just some text with no plan.';
+    const result = extractPlanBlock(response);
+    expect(result.plan).toBeNull();
+    expect(result.cleaned).toBe(response);
+  });
+
+  it('handles plan block with extra whitespace', () => {
+    const response = '```plan  \n  GOAL: Hold  \n```';
+    const result = extractPlanBlock(response);
+    expect(result.plan).toContain('GOAL: Hold');
+  });
+});

--- a/src/agent/llm/prompts.ts
+++ b/src/agent/llm/prompts.ts
@@ -1,6 +1,16 @@
 import { PROVINCES } from '../../engine/map';
 import { GameState, Message, OrderResolution, Power, Unit, UnitType } from '../../engine/types';
 
+const PLAN_BLOCK_RE = /```plan\s*\n([\s\S]*?)```/;
+
+export function extractPlanBlock(response: string): { plan: string | null; cleaned: string } {
+  const match = response.match(PLAN_BLOCK_RE);
+  if (!match) return { plan: null, cleaned: response };
+  const plan = match[1].trim();
+  const cleaned = response.replace(PLAN_BLOCK_RE, '').trim();
+  return { plan: plan || null, cleaned };
+}
+
 function unitStr(u: Unit): string {
   const t = u.type === UnitType.Army ? 'A' : 'F';
   const coast = u.coast ? `/${u.coast}` : '';
@@ -31,6 +41,97 @@ function formatMessage(m: Message, self: Power): string {
     tag = ` [SHARED - visible to: ${visible.join(', ')}]`;
   }
   return `${phaseLabel}${m.from} -> ${to}: ${m.content}${tag}`;
+}
+
+export function buildStrategicSummary(state: GameState, power: Power): string {
+  const lines: string[] = ['--- Strategic Situation ---'];
+
+  // Power rankings from current SC ownership
+  const currentSCs = new Map<Power, number>();
+  for (const [, p] of state.supplyCenters) {
+    currentSCs.set(p, (currentSCs.get(p) ?? 0) + 1);
+  }
+
+  // Starting SC counts derived from map data (not hardcoded)
+  const startingSCs = new Map<Power, number>();
+  for (const prov of Object.values(PROVINCES)) {
+    if (prov.homeCenter) {
+      const p = prov.homeCenter as Power;
+      startingSCs.set(p, (startingSCs.get(p) ?? 0) + 1);
+    }
+  }
+
+  const allPowers = Object.values(Power);
+  const ranked = allPowers
+    .map((p) => ({ power: p, scs: currentSCs.get(p) ?? 0, start: startingSCs.get(p) ?? 0 }))
+    .sort((a, b) => b.scs - a.scs);
+
+  lines.push('POWER RANKINGS (by supply centers):');
+  for (const { power: p, scs, start } of ranked) {
+    const delta = scs - start;
+    const trend = delta > 0 ? ` (+${delta})` : delta < 0 ? ` (${delta})` : '';
+    const arrow = delta > 0 ? ' ▲' : delta < 0 ? ' ▼' : '';
+    const you = p === power ? ' ← YOU' : '';
+    lines.push(`  ${p}: ${scs} SCs${trend}${arrow}${you}`);
+  }
+
+  // Neutral supply centers
+  const neutralSCs: string[] = [];
+  for (const [id, prov] of Object.entries(PROVINCES)) {
+    if (prov.supplyCenter && !state.supplyCenters.has(id)) {
+      neutralSCs.push(id);
+    }
+  }
+  if (neutralSCs.length > 0) {
+    lines.push(`\nNEUTRAL SUPPLY CENTERS (unclaimed — capture these!): ${neutralSCs.join(', ')}`);
+  }
+
+  // Neighbor detection
+  const myUnits = state.units.filter((u) => u.power === power);
+  const unitsByProvince = new Map<string, Unit>();
+  for (const u of state.units) {
+    unitsByProvince.set(u.province, u);
+  }
+
+  const neighborUnits = new Map<Power, string[]>();
+  for (const u of myUnits) {
+    const prov = PROVINCES[u.province];
+    const adj =
+      u.type === UnitType.Army
+        ? (prov?.adjacency.army ?? [])
+        : u.coast && prov?.adjacency.fleetByCoast?.[u.coast]
+          ? prov.adjacency.fleetByCoast[u.coast]!
+          : (prov?.adjacency.fleet ?? []);
+    for (const a of adj) {
+      const enemy = unitsByProvince.get(a);
+      if (enemy && enemy.power !== power) {
+        const list = neighborUnits.get(enemy.power) ?? [];
+        list.push(`${unitStr(enemy)} near ${u.province}`);
+        neighborUnits.set(enemy.power, list);
+      }
+    }
+  }
+
+  if (neighborUnits.size > 0) {
+    lines.push('\nYOUR NEIGHBORS (enemy units adjacent to yours):');
+    for (const [p, adjUnits] of neighborUnits) {
+      lines.push(`  ${p}: ${adjUnits.join(', ')}`);
+    }
+  }
+
+  // My position
+  const mySCCount = currentSCs.get(power) ?? 0;
+  const myHomeCenters = Object.entries(PROVINCES)
+    .filter(([, prov]) => prov.homeCenter === power)
+    .map(([id]) => id);
+  const lostHomes = myHomeCenters.filter((id) => state.supplyCenters.get(id) !== power);
+
+  lines.push(`\nYOUR POSITION: ${myUnits.length} units, ${mySCCount} supply centers`);
+  if (lostHomes.length > 0) {
+    lines.push(`  Lost home centers: ${lostHomes.join(', ')} — recapture these!`);
+  }
+
+  return lines.join('\n');
 }
 
 export function buildToolSystemPrompt(power: Power, endYear?: number): string {
@@ -76,13 +177,20 @@ HOW TO PLAY:
 - Use getProvinceInfo to scout enemy positions if needed
 - Use sendMessage to negotiate with other powers
 - During Orders/Retreats/Builds phases: you MUST call submitOrders/submitRetreats/submitBuilds before calling ready()
-- During the Diplomacy phase: only use sendMessage and ready() — no submission tools are available`;
+- During the Diplomacy phase: only use sendMessage and ready() — no submission tools are available
+
+PLANNING:
+- You have a persistent plan that carries over between phases
+- Include a \`\`\`plan block in your response alongside your tool calls
+- Format: GOAL (what you're trying to achieve), ALLIES, ENEMIES, NEXT (specific orders for next turn)
+- Your plan from last phase is shown in the turn prompt — review and update it`;
 }
 
 export function buildTurnPrompt(
   state: GameState,
   power: Power,
   pendingMessages: Message[],
+  plan?: string,
 ): string {
   const lines: string[] = [];
   const { phase } = state;
@@ -147,6 +255,17 @@ export function buildTurnPrompt(
   } else {
     lines.push('(none)');
   }
+
+  // Strategic situation (auto-computed)
+  lines.push('\n' + buildStrategicSummary(state, power));
+
+  // Agent plan (persisted across phases)
+  const planContent = plan ?? '(No plan yet — write one!)';
+  lines.push(
+    '\n--- Your Plan (from last phase) ---\n' +
+      planContent +
+      '\n\nReview your plan. Update it if the situation has changed by including a ```plan block in your response.',
+  );
 
   // Pending messages (phase labels included by formatMessage for temporal context)
   if (pendingMessages.length > 0) {

--- a/src/agent/llm/prompts.ts
+++ b/src/agent/llm/prompts.ts
@@ -63,13 +63,20 @@ INFORMATION SECURITY:
 - NEVER reveal information from a PRIVATE message to others
 - Use private messages for sensitive coordination
 
+STRATEGY:
+- Your goal is to GROW — capture supply centers to build more units
+- In early years, grab neutral supply centers (unowned SCs adjacent to your units)
+- NEVER hold all your units. A unit that holds when it could move toward a supply center is WASTED
+- Use Support orders to help your moves succeed against defended provinces
+- Coordinate with allies via sendMessage — but be ready to betray when it benefits you
+- Every turn, ask yourself: "Which supply center am I trying to capture next?"
+
 HOW TO PLAY:
-- Your units and reachable provinces are shown in the turn prompt — act on that info directly
+- Your units and reachable provinces are shown in the turn prompt
 - Use getProvinceInfo to scout enemy positions if needed
 - Use sendMessage to negotiate with other powers
 - During Orders/Retreats/Builds phases: you MUST call submitOrders/submitRetreats/submitBuilds before calling ready()
-- During the Diplomacy phase: only use sendMessage and ready() — no submission tools are available
-- Act quickly — submit orders first, then send messages if time permits`;
+- During the Diplomacy phase: only use sendMessage and ready() — no submission tools are available`;
 }
 
 export function buildTurnPrompt(
@@ -153,16 +160,43 @@ export function buildTurnPrompt(
   switch (phase.type) {
     case 'Diplomacy':
       lines.push(
-        '\nThis is the diplomacy phase. Send messages to negotiate. Call ready() when done.',
+        '\nThis is the diplomacy phase. Use sendMessage to:' +
+          '\n- Propose alliances and coordinate attacks on shared enemies' +
+          '\n- Agree on which neutral SCs each power will take' +
+          '\n- Warn neighbors against attacking you' +
+          '\nSend at least one message, then call ready() when done.',
       );
       break;
-    case 'Orders':
+    case 'Orders': {
+      // Identify nearby unowned SCs to suggest targets
+      const targets: string[] = [];
+      for (const u of myUnits) {
+        const prov = PROVINCES[u.province];
+        const adj =
+          u.type === UnitType.Army
+            ? (prov?.adjacency.army ?? [])
+            : u.coast && prov?.adjacency.fleetByCoast?.[u.coast]
+              ? prov.adjacency.fleetByCoast[u.coast]!
+              : (prov?.adjacency.fleet ?? []);
+        for (const a of adj) {
+          const target = PROVINCES[a];
+          if (target?.supplyCenter && !state.supplyCenters.has(a)) {
+            targets.push(`${unitStr(u)} can reach neutral SC: ${a}`);
+          }
+        }
+      }
+      const targetHint =
+        targets.length > 0
+          ? `\n\nNEARBY NEUTRAL SUPPLY CENTERS (capture these!):\n${targets.join('\n')}`
+          : '';
       lines.push(
         '\n⚠️ ACTION REQUIRED: You MUST call submitOrders with one order per unit, then call ready().' +
-          '\nYour units and their reachable provinces are listed above — you have everything you need.' +
-          '\nYou may use getProvinceInfo to scout, but do NOT re-query your own units or adjacencies.',
+          '\nDo NOT hold all units — move toward supply centers! Holding every unit is losing.' +
+          '\nUse Move orders to advance, Support orders to help allies or reinforce your own moves.' +
+          targetHint,
       );
       break;
+    }
     case 'Retreats':
       lines.push(
         '\n⚠️ ACTION REQUIRED: You MUST call the submitRetreats tool.' +
@@ -173,11 +207,26 @@ export function buildTurnPrompt(
     case 'Builds': {
       const buildCount = mySCs - myUnits.length;
       if (buildCount > 0) {
+        // Find open home centers for build suggestions
+        const homeCenters = [...state.supplyCenters.entries()]
+          .filter(([, p]) => p === power)
+          .map(([prov]) => prov)
+          .filter((prov) => PROVINCES[prov]?.homeCenter === power)
+          .filter((prov) => !state.units.some((u) => u.province === prov));
+        const homeList =
+          homeCenters.length > 0
+            ? `\nYour open home centers: ${homeCenters.join(', ')}`
+            : '\nWARNING: All home centers are occupied — you must Waive.';
+        const example =
+          homeCenters.length > 0
+            ? `\nExample: submitBuilds({ builds: [{ type: "Build", unitType: "Army", province: "${homeCenters[0]}" }] })`
+            : '\nExample: submitBuilds({ builds: [{ type: "Waive" }] })';
         lines.push(
           `\n⚠️ ACTION REQUIRED: You have ${mySCs} supply centers and ${myUnits.length} units — you MUST build ${buildCount} unit(s).` +
-            '\nCall submitBuilds with an array of Build orders. Each build needs: type "Build", unitType ("Army" or "Fleet"), and province (one of your unoccupied home centers).' +
-            '\nFor fleet builds on multi-coast provinces (stp, spa, bul), you MUST specify coast: e.g. province "stp" with coast "nc" or "sc".' +
-            '\nIf all your home centers are occupied, use type "Waive" instead (no unitType or province needed).' +
+            homeList +
+            example +
+            '\nDo NOT submit an empty array — you must build units to grow stronger!' +
+            '\nFor fleet builds on multi-coast provinces (stp, spa, bul), specify coast: "nc" or "sc".' +
             '\nThen call ready().',
         );
       } else if (buildCount < 0) {

--- a/src/agent/llm/prompts.ts
+++ b/src/agent/llm/prompts.ts
@@ -171,6 +171,7 @@ STRATEGY:
 - Use Support orders to help your moves succeed against defended provinces
 - Coordinate with allies via sendMessage — but be ready to betray when it benefits you
 - Every turn, ask yourself: "Which supply center am I trying to capture next?"
+- MOMENTUM: If you moved toward a target last turn, CONTINUE in that direction. Do not retreat home unless directly threatened. Sustained campaigns win games — oscillating back and forth wastes turns.
 
 HOW TO PLAY:
 - Your units and reachable provinces are shown in the turn prompt
@@ -180,10 +181,10 @@ HOW TO PLAY:
 - During the Diplomacy phase: only use sendMessage and ready() — no submission tools are available
 
 PLANNING:
-- You have a persistent plan that carries over between phases
-- Include a \`\`\`plan block in your response alongside your tool calls
-- Format: GOAL (what you're trying to achieve), ALLIES, ENEMIES, NEXT (specific orders for next turn)
-- Your plan from last phase is shown in the turn prompt — review and update it`;
+- You MUST include a \`\`\`plan block in EVERY response — this is your memory between turns
+- Your old plan is shown in the turn prompt. It may be OUTDATED — always rewrite it based on current state
+- Format: GOAL (what SC are you targeting next?), ALLIES, ENEMIES, NEXT (specific orders for next turn)
+- A stale plan is worse than no plan — update it every phase`;
 }
 
 export function buildTurnPrompt(
@@ -264,7 +265,7 @@ export function buildTurnPrompt(
   lines.push(
     '\n--- Your Plan (from last phase) ---\n' +
       planContent +
-      '\n\nReview your plan. Update it if the situation has changed by including a ```plan block in your response.',
+      '\n\n⚠️ You MUST include an updated ```plan block in your response. Rewrite your plan based on the current situation above.',
   );
 
   // Pending messages (phase labels included by formatMessage for temporal context)
@@ -336,10 +337,18 @@ export function buildTurnPrompt(
           homeCenters.length > 0
             ? `\nYour open home centers: ${homeCenters.join(', ')}`
             : '\nWARNING: All home centers are occupied — you must Waive.';
-        const example =
-          homeCenters.length > 0
-            ? `\nExample: submitBuilds({ builds: [{ type: "Build", unitType: "Army", province: "${homeCenters[0]}" }] })`
-            : '\nExample: submitBuilds({ builds: [{ type: "Waive" }] })';
+        // Build exact example showing all builds needed
+        let example: string;
+        if (homeCenters.length > 0) {
+          const buildOrders = homeCenters
+            .slice(0, buildCount)
+            .map((prov) => `{ type: "Build", unitType: "Army", province: "${prov}" }`)
+            .join(', ');
+          example = `\nCopy this EXACTLY: submitBuilds({ builds: [${buildOrders}] })`;
+        } else {
+          const waives = Array.from({ length: buildCount }, () => '{ type: "Waive" }').join(', ');
+          example = `\nCopy this EXACTLY: submitBuilds({ builds: [${waives}] })`;
+        }
         lines.push(
           `\n⚠️ ACTION REQUIRED: You have ${mySCs} supply centers and ${myUnits.length} units — you MUST build ${buildCount} unit(s).` +
             homeList +

--- a/src/agent/llm/prompts.ts
+++ b/src/agent/llm/prompts.ts
@@ -183,8 +183,13 @@ HOW TO PLAY:
 PLANNING:
 - You MUST include a \`\`\`plan block in EVERY response — this is your memory between turns
 - Your old plan is shown in the turn prompt. It may be OUTDATED — always rewrite it based on current state
-- Format: GOAL (what SC are you targeting next?), ALLIES, ENEMIES, NEXT (specific orders for next turn)
-- A stale plan is worse than no plan — update it every phase`;
+- Use this format:
+  GOAL: What supply center am I targeting next and why?
+  ALLIES: Who am I working with? What did we agree to?
+  THREATS: Who is threatening me? What are they likely to do next turn?
+  ORDERS: What EXACTLY will I submit next turn? (e.g. A vie -> bud, F tri -> alb)
+  REFLECTION: What worked last turn? What failed? What should I change?
+- The ORDERS field is critical — pre-commit to specific moves so you follow through next turn`;
 }
 
 export function buildTurnPrompt(
@@ -261,11 +266,12 @@ export function buildTurnPrompt(
   lines.push('\n' + buildStrategicSummary(state, power));
 
   // Agent plan (persisted across phases)
-  const planContent = plan ?? '(No plan yet — write one!)';
+  const planContent =
+    plan ?? '(No plan yet — write one using the format: GOAL, ALLIES, THREATS, ORDERS, REFLECTION)';
   lines.push(
     '\n--- Your Plan (from last phase) ---\n' +
       planContent +
-      '\n\n⚠️ You MUST include an updated ```plan block in your response. Rewrite your plan based on the current situation above.',
+      '\n\n⚠️ You MUST include an updated ```plan block. Check your ORDERS from last phase — did you follow through? Update based on results.',
   );
 
   // Pending messages (phase labels included by formatMessage for temporal context)

--- a/src/agent/llm/prompts.ts
+++ b/src/agent/llm/prompts.ts
@@ -337,24 +337,16 @@ export function buildTurnPrompt(
           homeCenters.length > 0
             ? `\nYour open home centers: ${homeCenters.join(', ')}`
             : '\nWARNING: All home centers are occupied — you must Waive.';
-        // Build exact example showing all builds needed
-        let example: string;
-        if (homeCenters.length > 0) {
-          const buildOrders = homeCenters
-            .slice(0, buildCount)
-            .map((prov) => `{ type: "Build", unitType: "Army", province: "${prov}" }`)
-            .join(', ');
-          example = `\nCopy this EXACTLY: submitBuilds({ builds: [${buildOrders}] })`;
-        } else {
-          const waives = Array.from({ length: buildCount }, () => '{ type: "Waive" }').join(', ');
-          example = `\nCopy this EXACTLY: submitBuilds({ builds: [${waives}] })`;
-        }
+        const buildInstructions =
+          homeCenters.length > 0
+            ? '\nCall submitBuilds with a Build order for each unit. Each needs: type "Build", unitType "Army" or "Fleet", province (one of your open home centers above).' +
+              '\nFor fleet builds on multi-coast provinces (stp, spa, bul), also specify coast: "nc" or "sc".'
+            : '\nAll home centers are occupied. Call submitBuilds with Waive orders: type "Waive" (no unitType or province needed).';
         lines.push(
-          `\n⚠️ ACTION REQUIRED: You have ${mySCs} supply centers and ${myUnits.length} units — you MUST build ${buildCount} unit(s).` +
+          `\n⚠️ ACTION REQUIRED: You MUST build ${buildCount} unit(s).` +
             homeList +
-            example +
-            '\nDo NOT submit an empty array — you must build units to grow stronger!' +
-            '\nFor fleet builds on multi-coast provinces (stp, spa, bul), specify coast: "nc" or "sc".' +
+            buildInstructions +
+            '\nDo NOT submit an empty array — you must build to grow stronger!' +
             '\nThen call ready().',
         );
       } else if (buildCount < 0) {

--- a/src/agent/llm/semaphore.test.ts
+++ b/src/agent/llm/semaphore.test.ts
@@ -1,0 +1,128 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FileSemaphore } from './semaphore';
+
+const lockDir = join(tmpdir(), 'diplomaicy-llm-locks');
+
+function cleanLockDir() {
+  rmSync(lockDir, { recursive: true, force: true });
+}
+
+afterEach(cleanLockDir);
+
+describe('FileSemaphore', () => {
+  it('acquires immediately when slots are free', async () => {
+    const sem = new FileSemaphore(2);
+    await sem.acquire();
+    expect(existsSync(join(lockDir, 'slot-0'))).toBe(true);
+    sem.release();
+  });
+
+  it('creates lock directory with pid file', async () => {
+    const sem = new FileSemaphore(1);
+    await sem.acquire();
+    const pidFile = join(lockDir, 'slot-0', 'pid');
+    expect(existsSync(pidFile)).toBe(true);
+    sem.release();
+  });
+
+  it('release removes the slot directory', async () => {
+    const sem = new FileSemaphore(1);
+    await sem.acquire();
+    expect(existsSync(join(lockDir, 'slot-0'))).toBe(true);
+    sem.release();
+    expect(existsSync(join(lockDir, 'slot-0'))).toBe(false);
+  });
+
+  it('release is idempotent', async () => {
+    const sem = new FileSemaphore(1);
+    await sem.acquire();
+    sem.release();
+    sem.release(); // should not throw
+  });
+
+  it('blocks when all slots are taken then acquires on release', async () => {
+    const sem1 = new FileSemaphore(1);
+    await sem1.acquire();
+
+    const sem2 = new FileSemaphore(1);
+    let acquired = false;
+    const waiting = sem2.acquire().then(() => {
+      acquired = true;
+    });
+
+    // Give the poll loop a chance to spin
+    await new Promise((r) => setTimeout(r, 200));
+    expect(acquired).toBe(false);
+
+    sem1.release();
+    await waiting;
+    expect(acquired).toBe(true);
+
+    sem2.release();
+  });
+
+  it('supports N concurrent holders', async () => {
+    const sem1 = new FileSemaphore(2);
+    const sem2 = new FileSemaphore(2);
+    await sem1.acquire();
+    await sem2.acquire();
+
+    expect(existsSync(join(lockDir, 'slot-0'))).toBe(true);
+    expect(existsSync(join(lockDir, 'slot-1'))).toBe(true);
+
+    sem1.release();
+    sem2.release();
+  });
+
+  it('cleans up stale locks from dead processes on startup', () => {
+    // Simulate a stale lock left by a non-existent process
+    const slotDir = join(lockDir, 'slot-0');
+    mkdirSync(slotDir, { recursive: true });
+    writeFileSync(join(slotDir, 'pid'), '999999999');
+
+    // FileSemaphore constructor should clean it up
+    const sem = new FileSemaphore(1);
+    expect(existsSync(slotDir)).toBe(false);
+    sem.release();
+  });
+
+  it('does not clean locks held by a live process', async () => {
+    // Use our own pid — definitely alive
+    const slotDir = join(lockDir, 'slot-0');
+    mkdirSync(slotDir, { recursive: true });
+    writeFileSync(join(slotDir, 'pid'), String(process.pid));
+
+    // Constructor should NOT remove our live lock
+    const sem = new FileSemaphore(1);
+    expect(existsSync(slotDir)).toBe(true);
+
+    // Clean up manually so other tests aren't affected
+    rmSync(slotDir, { recursive: true, force: true });
+    sem.release();
+  });
+
+  it('works under contention from concurrent acquirers', async () => {
+    const concurrency = 2;
+    let maxConcurrent = 0;
+    let current = 0;
+
+    const task = async () => {
+      const sem = new FileSemaphore(concurrency);
+      await sem.acquire();
+      current++;
+      maxConcurrent = Math.max(maxConcurrent, current);
+      await new Promise((r) => setTimeout(r, 50));
+      current--;
+      sem.release();
+    };
+
+    await Promise.all(Array.from({ length: 6 }, () => task()));
+
+    expect(maxConcurrent).toBeLessThanOrEqual(concurrency);
+    expect(current).toBe(0);
+  });
+});

--- a/src/agent/llm/semaphore.ts
+++ b/src/agent/llm/semaphore.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { logger } from '../../util/logger';
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Cross-process semaphore using filesystem locks (mkdir is atomic).
+ * Each slot is a directory; acquiring = creating it, releasing = removing it.
+ * Supports N concurrent holders via N slot directories.
+ */
+export class FileSemaphore {
+  private readonly lockDir: string;
+  private heldSlot: number | null = null;
+
+  constructor(private readonly max: number) {
+    this.lockDir = join(tmpdir(), 'diplomaicy-llm-locks');
+    mkdirSync(this.lockDir, { recursive: true });
+
+    // Clean up stale locks from crashed processes on startup
+    for (let i = 0; i < max; i++) {
+      const slotDir = this.slotPath(i);
+      try {
+        const pidFile = join(slotDir, 'pid');
+        const pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
+        if (!isProcessAlive(pid)) {
+          rmSync(slotDir, { recursive: true, force: true });
+          logger.debug(`[LLM] Cleaned stale lock slot-${i} (pid ${pid})`);
+        }
+      } catch {
+        // No slot dir or no pid file — nothing to clean
+      }
+    }
+
+    // Release our slot on process exit
+    const cleanup = () => this.release();
+    process.on('exit', cleanup);
+    process.on('SIGTERM', cleanup);
+    process.on('SIGINT', cleanup);
+  }
+
+  private slotPath(i: number): string {
+    return join(this.lockDir, `slot-${i}`);
+  }
+
+  async acquire(): Promise<void> {
+    while (true) {
+      for (let i = 0; i < this.max; i++) {
+        const dir = this.slotPath(i);
+        try {
+          mkdirSync(dir);
+          writeFileSync(join(dir, 'pid'), String(process.pid));
+          this.heldSlot = i;
+          return;
+        } catch {
+          // Slot taken
+        }
+      }
+      logger.debug(`[LLM] All ${this.max} slots busy, waiting...`);
+      await new Promise((r) => setTimeout(r, 100 + Math.random() * 400));
+    }
+  }
+
+  release(): void {
+    if (this.heldSlot !== null) {
+      try {
+        rmSync(this.slotPath(this.heldSlot), { recursive: true, force: true });
+      } catch {
+        // Already removed
+      }
+      this.heldSlot = null;
+    }
+  }
+}
+
+// Limit concurrent LLM requests across all agent processes.
+// With 7 agents each running tool loops, requests pile up and hit undici's
+// 5-minute headersTimeout. The file semaphore ensures at most N requests
+// reach Ollama at once, with the rest waiting in-process (no timeout).
+const LLM_CONCURRENCY = parseInt(process.env.LLM_CONCURRENCY ?? '1', 10);
+export const llmSemaphore = new FileSemaphore(LLM_CONCURRENCY);

--- a/src/agent/llm/semaphore.ts
+++ b/src/agent/llm/semaphore.ts
@@ -42,10 +42,15 @@ export class FileSemaphore {
     }
 
     // Release our slot on process exit
-    const cleanup = () => this.release();
-    process.on('exit', cleanup);
-    process.on('SIGTERM', cleanup);
-    process.on('SIGINT', cleanup);
+    process.on('exit', () => this.release());
+    process.on('SIGTERM', () => {
+      this.release();
+      process.exit(128 + 15);
+    });
+    process.on('SIGINT', () => {
+      this.release();
+      process.exit(128 + 2);
+    });
   }
 
   private slotPath(i: number): string {

--- a/src/agent/llm/semaphore.ts
+++ b/src/agent/llm/semaphore.ts
@@ -8,7 +8,12 @@ function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err: unknown) {
+    // EPERM means process exists but we lack permission to signal it
+    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EPERM') {
+      return true;
+    }
+    // ESRCH means no such process
     return false;
   }
 }
@@ -91,5 +96,5 @@ export class FileSemaphore {
 // With 7 agents each running tool loops, requests pile up and hit undici's
 // 5-minute headersTimeout. The file semaphore ensures at most N requests
 // reach Ollama at once, with the rest waiting in-process (no timeout).
-const LLM_CONCURRENCY = parseInt(process.env.LLM_CONCURRENCY ?? '1', 10);
+const LLM_CONCURRENCY = Math.max(1, parseInt(process.env.LLM_CONCURRENCY ?? '1', 10) || 1);
 export const llmSemaphore = new FileSemaphore(LLM_CONCURRENCY);

--- a/src/agent/llm/tool-agent.ts
+++ b/src/agent/llm/tool-agent.ts
@@ -1,4 +1,6 @@
 import type { Unsubscribable } from '@trpc/server/observable';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
 
 import type { GameState } from '../../engine/types';
 import { Message, PhaseType, Power } from '../../engine/types';
@@ -6,7 +8,7 @@ import { logger } from '../../util/logger';
 import type { GameClient } from '../remote/client';
 import { deserializeGameState, type SerializedGameState } from '../remote/deserialize';
 import type { LLMClient, ToolDefinition } from './llm-client';
-import { buildToolSystemPrompt, buildTurnPrompt } from './prompts';
+import { buildToolSystemPrompt, buildTurnPrompt, extractPlanBlock } from './prompts';
 import { GameToolExecutor, TOOL_DEFINITIONS, type ToolGameClient } from './tools';
 
 const MAP_QUERY_TOOLS = [
@@ -45,6 +47,7 @@ export async function connectToolAgent(
   llm: LLMClient,
   power: Power,
   lobbyId: string,
+  planDir?: string,
 ): Promise<{ unsubscribe: () => void }> {
   // 1. Fetch initial state
   const serializedState = await client.game.getState.query({ lobbyId });
@@ -52,6 +55,24 @@ export async function connectToolAgent(
 
   // 2. Build system prompt (once at init)
   const systemPrompt = buildToolSystemPrompt(power, initialState.endYear);
+
+  // ── Plan persistence ─────────────────────────────────────────────
+  const planFilePath = planDir ? join(planDir, lobbyId, `${power}-plan.md`) : null;
+
+  async function readPlan(): Promise<string | undefined> {
+    if (!planFilePath) return undefined;
+    try {
+      return await readFile(planFilePath, 'utf-8');
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function savePlan(plan: string): Promise<void> {
+    if (!planFilePath) return;
+    await mkdir(dirname(planFilePath), { recursive: true });
+    await writeFile(planFilePath, plan);
+  }
 
   // ── Serialized work queue + message accumulator ──────────────────
   const MESSAGE_BATCH_DELAY = parseInt(process.env.MESSAGE_BATCH_DELAY ?? '5000', 10);
@@ -162,11 +183,13 @@ export async function connectToolAgent(
         `[${power}] Including ${accumulatedMessages.length} accumulated messages in phase prompt`,
       );
     }
-    const userMessage = buildTurnPrompt(gameState, power, accumulatedMessages);
+    const currentPlan = await readPlan();
+    const userMessage = buildTurnPrompt(gameState, power, accumulatedMessages, currentPlan);
 
     logger.info(`[${power}] Starting tool loop for phase ${gameState.phase.type}`);
+    let response = '';
     try {
-      await llm.runToolLoop(
+      response = await llm.runToolLoop(
         [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userMessage },
@@ -175,6 +198,15 @@ export async function connectToolAgent(
         executor,
       );
       logger.info(`[${power}] Tool loop complete for phase ${gameState.phase.type}`);
+
+      // Extract and persist plan block from primary response
+      if (response) {
+        const { plan } = extractPlanBlock(response);
+        if (plan) {
+          await savePlan(plan);
+          logger.info(`[${power}] Plan saved for next phase`);
+        }
+      }
     } catch (err) {
       logger.error(`[${power}] Tool loop error:`, err);
     }
@@ -234,7 +266,8 @@ export async function connectToolAgent(
       const executor = new GameToolExecutor(client as unknown as ToolGameClient, gameState, power);
       const tools = filterToolsByPhase(gameState.phase.type as PhaseType);
       // Pass ALL accumulated messages so the agent has full diplomatic context
-      const userMessage = buildTurnPrompt(gameState, power, accumulatedMessages);
+      const messagePlan = await readPlan();
+      const userMessage = buildTurnPrompt(gameState, power, accumulatedMessages, messagePlan);
 
       logger.info(
         `[${power}] Starting tool loop for ${newMessages.length} new message(s) (${accumulatedMessages.length} total context)`,

--- a/src/agent/llm/tools.ts
+++ b/src/agent/llm/tools.ts
@@ -576,14 +576,23 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         properties: {
           to: {
             oneOf: [
-              { type: 'string', description: 'Target power name or "Global"' },
+              {
+                type: 'string',
+                enum: ['eng', 'fra', 'ger', 'ita', 'aus', 'rus', 'tur', 'Global'],
+                description:
+                  'Single recipient: a power abbreviation (eng, fra, ger, ita, aus, rus, tur) or "Global" for all',
+              },
               {
                 type: 'array',
-                items: { type: 'string' },
-                description: 'List of target power names',
+                items: {
+                  type: 'string',
+                  enum: ['eng', 'fra', 'ger', 'ita', 'aus', 'rus', 'tur'],
+                },
+                description: 'List of power abbreviations to send to',
               },
             ],
-            description: 'Recipient(s) of the message',
+            description:
+              'Recipient(s): use power abbreviations (eng, fra, ger, ita, aus, rus, tur) or "Global"',
           },
           content: { type: 'string', description: 'Message content' },
         },

--- a/src/agent/remote/deserialize.ts
+++ b/src/agent/remote/deserialize.ts
@@ -21,7 +21,7 @@ export interface SerializedGameState {
   map: Record<string, ProvinceState>;
   orderHistory: Record<string, WireOrderRound[]>;
   retreatSituations: RetreatSituation[];
-  endYear: number;
+  endYear?: number;
   deadlineMs: number;
   gameOver?: boolean;
 }

--- a/src/agent/remote/run.ts
+++ b/src/agent/remote/run.ts
@@ -14,12 +14,19 @@ function isPower(value: string): value is Power {
   return VALID_POWERS.has(value);
 }
 
-function parseArgs(): { power: Power; server: string; type?: string; lobbyId: string } {
+function parseArgs(): {
+  power: Power;
+  server: string;
+  type?: string;
+  lobbyId: string;
+  planDir?: string;
+} {
   const args = process.argv.slice(2);
   let power: string | undefined;
   let server = process.env.GAME_SERVER ?? 'http://localhost:3000/trpc';
   let type: string | undefined;
   let lobbyId: string | undefined;
+  let planDir: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--power' && args[i + 1]) {
@@ -30,6 +37,8 @@ function parseArgs(): { power: Power; server: string; type?: string; lobbyId: st
       type = args[++i];
     } else if (args[i] === '--lobby' && args[i + 1]) {
       lobbyId = args[++i];
+    } else if (args[i] === '--plan-dir' && args[i + 1]) {
+      planDir = args[++i];
     }
   }
 
@@ -49,7 +58,7 @@ function parseArgs(): { power: Power; server: string; type?: string; lobbyId: st
     process.exit(1);
   }
 
-  return { power, server, type, lobbyId };
+  return { power, server, type, lobbyId, planDir };
 }
 
 function resolveAgentConfig(power: Power, typeOverride?: string): AgentConfig {
@@ -79,7 +88,7 @@ function resolveAgentConfig(power: Power, typeOverride?: string): AgentConfig {
 }
 
 async function main() {
-  const { power, server, type, lobbyId } = parseArgs();
+  const { power, server, type, lobbyId, planDir } = parseArgs();
   const cfg = resolveAgentConfig(power, type);
 
   // Step 1: Join lobby to get seat token (unauthenticated client)
@@ -131,7 +140,7 @@ async function main() {
       `Starting tool-calling agent for ${power} (${cfg.provider ?? 'openai'}/${cfg.model}), connecting to ${server}...`,
     );
     // connectToolAgent handles everything — joins directly into tool loop
-    await connectToolAgent(trpcClient, llmClient, power, lobbyId);
+    await connectToolAgent(trpcClient, llmClient, power, lobbyId, planDir);
   } else if (!cfg.type || cfg.type === 'random') {
     console.log(`Starting random agent for ${power}, connecting to ${server}...`);
     await connectRandomAgent(trpcClient, power, lobbyId);

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -180,7 +180,7 @@ export interface GameState {
   supplyCenters: Map<string, Power>; // province id -> owning power
   orderHistory: OrderResolution[][];
   retreatSituations: RetreatSituation[];
-  endYear: number; // final year of the game (e.g. 1901 for a 1-year game)
+  endYear?: number; // final year of the game. undefined = no year limit (victory/draw only)
 }
 
 // === Province State (wire format) ===

--- a/src/game/describe.ts
+++ b/src/game/describe.ts
@@ -31,7 +31,7 @@ export const describeProcedure = publicProcedure.query(() => ({
         type: 'mutation',
         input: {
           name: 'string (required)',
-          maxYears: 'number (default: 10)',
+          maxYears: 'number (default: none)',
           victoryThreshold: 'number (default: 18)',
           startYear: 'number (default: 1901)',
           phaseDelayMs: 'number (default: 0)',

--- a/src/game/lobby-manager.ts
+++ b/src/game/lobby-manager.ts
@@ -6,7 +6,7 @@ import { GameManager, type GameResult } from './manager';
 
 export interface LobbyConfig {
   name: string;
-  maxYears: number;
+  maxYears?: number;
   victoryThreshold: number;
   startYear: number;
   phaseDelayMs: number;

--- a/src/game/lobby-router.ts
+++ b/src/game/lobby-router.ts
@@ -29,7 +29,7 @@ const agentConfigSchema = z.object({
 
 const lobbyConfigSchema = z.object({
   name: z.string().min(1).max(100),
-  maxYears: z.number().int().min(1).max(100).default(10),
+  maxYears: z.number().int().min(1).optional(),
   victoryThreshold: z.number().int().min(1).max(34).default(18),
   startYear: z.number().int().min(1).max(9999).default(1901),
   phaseDelayMs: z.number().int().min(0).default(0),
@@ -62,7 +62,7 @@ function serializeLobby(lobby: Lobby) {
 }
 
 export interface LobbyDefaults {
-  maxYears: number;
+  maxYears?: number;
   phaseDelayMs: number;
   remoteTimeoutMs: number;
   pressDelayMin: number;

--- a/src/game/manager.test.ts
+++ b/src/game/manager.test.ts
@@ -71,7 +71,7 @@ describe('GameManager — Initialization', () => {
     expect(state.phase.type).toBe(PhaseType.Diplomacy);
     expect(state.units).toHaveLength(22);
     expect(state.supplyCenters.size).toBe(22);
-    expect(state.endYear).toBe(1950);
+    expect(state.endYear).toBeUndefined();
   });
 });
 

--- a/src/game/manager.ts
+++ b/src/game/manager.ts
@@ -80,7 +80,7 @@ export class GameManager {
   private eventListeners: GameEventListener[] = [];
   private phaseChangeListeners: PhaseChangeListener[] = [];
   private startYear: number;
-  private endYear: number;
+  private endYear: number | undefined;
   private phaseDelayMs: number;
   private remoteTimeoutMs: number;
   private victoryThreshold: number;
@@ -100,7 +100,7 @@ export class GameManager {
 
   constructor(config: GameManagerConfig = {}) {
     const {
-      maxYears = 50,
+      maxYears,
       phaseDelayMs = 0,
       remoteTimeoutMs = 0,
       pressDelayMin = 0,
@@ -112,7 +112,7 @@ export class GameManager {
     } = config;
     this.bus = new MessageBus({ pressDelayMin, pressDelayMax });
     this.startYear = startYear;
-    this.endYear = startYear - 1 + maxYears;
+    this.endYear = maxYears !== undefined ? startYear - 1 + maxYears : undefined;
     this.phaseDelayMs = phaseDelayMs;
     this.remoteTimeoutMs = remoteTimeoutMs;
     this.victoryThreshold = victoryThreshold;
@@ -299,7 +299,7 @@ export class GameManager {
     });
 
     // Main game loop
-    while (this.state.phase.year <= this.endYear) {
+    while (this.endYear === undefined || this.state.phase.year <= this.endYear) {
       // Spring
       await this.runDiplomacyPhase(Season.Spring);
       const springDraw = this.checkDrawVote();

--- a/src/game/manager.ts
+++ b/src/game/manager.ts
@@ -445,8 +445,10 @@ export class GameManager {
   private async runOrdersPhase(season: Season): Promise<void> {
     await this.startPhase({ year: this.state.phase.year, season, type: PhaseType.Orders });
 
+    const deadlineMs = this.phaseDelayMs > 0 ? Date.now() + this.phaseDelayMs : undefined;
+
     // Wait for all active powers to submit orders
-    const orderMap = await this.collectOrders();
+    const orderMap = await this.collectOrders(deadlineMs);
 
     // Resolve orders
     const result = resolveOrders(this.state.units, orderMap, PROVINCES);
@@ -468,7 +470,7 @@ export class GameManager {
 
     // Handle retreats if any
     if (result.dislodgedUnits.length > 0) {
-      await this.runRetreatsPhase(season, result);
+      await this.runRetreatsPhase(season, result, deadlineMs);
     } else {
       this.state.units = result.newPositions;
       this.state.retreatSituations = [];
@@ -480,12 +482,13 @@ export class GameManager {
   private async runRetreatsPhase(
     season: Season,
     resolutionResult: ResolutionResult,
+    deadlineMs?: number,
   ): Promise<void> {
     this.state.retreatSituations = resolutionResult.dislodgedUnits;
     await this.startPhase({ year: this.state.phase.year, season, type: PhaseType.Retreats });
 
     // Wait for affected powers to submit retreats
-    const allRetreatOrders = await this.collectRetreats(resolutionResult);
+    const allRetreatOrders = await this.collectRetreats(resolutionResult, deadlineMs);
 
     // Process retreat orders
     const newPositions = [...resolutionResult.newPositions];
@@ -545,8 +548,10 @@ export class GameManager {
       type: PhaseType.Builds,
     });
 
+    const deadlineMs = this.phaseDelayMs > 0 ? Date.now() + this.phaseDelayMs : undefined;
+
     // Wait for powers that need to build/disband to submit
-    const allBuildOrders = await this.collectBuilds();
+    const allBuildOrders = await this.collectBuilds(deadlineMs);
 
     const turnRecord: TurnRecord = {
       phase: { ...this.state.phase },
@@ -604,9 +609,20 @@ export class GameManager {
     if (readyGate) readyGate();
   }
 
-  /** Wraps a promise with an optional timeout. Returns true if timed out. */
-  private withTimeout(promise: Promise<void>, power: Power, label: string): Promise<boolean> {
-    if (this.remoteTimeoutMs <= 0) return promise.then(() => false);
+  /** Wraps a promise with an optional timeout. Returns true if timed out.
+   * If deadlineMs is provided, uses whichever limit fires first. */
+  private withTimeout(
+    promise: Promise<void>,
+    power: Power,
+    label: string,
+    deadlineMs?: number,
+  ): Promise<boolean> {
+    let timeoutMs: number | undefined = this.remoteTimeoutMs > 0 ? this.remoteTimeoutMs : undefined;
+    if (deadlineMs !== undefined) {
+      const remaining = Math.max(0, deadlineMs - Date.now());
+      timeoutMs = timeoutMs !== undefined ? Math.min(timeoutMs, remaining) : remaining;
+    }
+    if (timeoutMs === undefined) return promise.then(() => false);
     let timer: ReturnType<typeof setTimeout>;
     return Promise.race([
       promise.then(() => {
@@ -615,16 +631,14 @@ export class GameManager {
       }),
       new Promise<boolean>((resolve) => {
         timer = setTimeout(() => {
-          logger.warn(
-            `[${power}] ${label} timed out after ${this.remoteTimeoutMs}ms — using defaults`,
-          );
+          logger.warn(`[${power}] ${label} timed out after ${timeoutMs}ms — using defaults`);
           resolve(true);
-        }, this.remoteTimeoutMs);
+        }, timeoutMs);
       }),
     ]);
   }
 
-  private async collectOrders(): Promise<Map<string, Order>> {
+  private async collectOrders(deadlineMs?: number): Promise<Map<string, Order>> {
     const activePowers = this.getActivePowers();
     const orderMap = new Map<string, Order>();
 
@@ -645,7 +659,7 @@ export class GameManager {
         });
       });
 
-      const timedOut = await this.withTimeout(gate, power, 'orders');
+      const timedOut = await this.withTimeout(gate, power, 'orders', deadlineMs);
       if (timedOut) {
         this.orderGates.delete(power);
         // Default: Hold all units
@@ -657,11 +671,18 @@ export class GameManager {
       }
     });
 
-    await Promise.all(promises);
+    const waitForDeadline =
+      deadlineMs !== undefined && !this.fastAdjudication
+        ? new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, deadlineMs - Date.now())))
+        : Promise.resolve();
+    await Promise.all([Promise.all(promises), waitForDeadline]);
     return orderMap;
   }
 
-  private async collectRetreats(resolutionResult: ResolutionResult): Promise<RetreatOrder[]> {
+  private async collectRetreats(
+    resolutionResult: ResolutionResult,
+    deadlineMs?: number,
+  ): Promise<RetreatOrder[]> {
     const affectedPowers = new Set(resolutionResult.dislodgedUnits.map((d) => d.unit.power));
     const allRetreatOrders: RetreatOrder[] = [];
 
@@ -675,7 +696,7 @@ export class GameManager {
         });
       });
 
-      const timedOut = await this.withTimeout(gate, power, 'retreats');
+      const timedOut = await this.withTimeout(gate, power, 'retreats', deadlineMs);
       if (timedOut) {
         this.retreatGates.delete(power);
         // Default: Disband all dislodged units
@@ -687,11 +708,15 @@ export class GameManager {
       }
     });
 
-    await Promise.all(promises);
+    const waitForDeadline =
+      deadlineMs !== undefined && !this.fastAdjudication
+        ? new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, deadlineMs - Date.now())))
+        : Promise.resolve();
+    await Promise.all([Promise.all(promises), waitForDeadline]);
     return allRetreatOrders;
   }
 
-  private async collectBuilds(): Promise<BuildOrder[]> {
+  private async collectBuilds(deadlineMs?: number): Promise<BuildOrder[]> {
     const activePowers = this.getActivePowers();
     const allBuildOrders: BuildOrder[] = [];
 
@@ -711,7 +736,7 @@ export class GameManager {
         });
       });
 
-      const timedOut = await this.withTimeout(gate, power, 'builds');
+      const timedOut = await this.withTimeout(gate, power, 'builds', deadlineMs);
       if (timedOut) {
         this.buildGates.delete(power);
         if (buildCount > 0) {
@@ -736,7 +761,11 @@ export class GameManager {
       }
     });
 
-    await Promise.all(promises);
+    const waitForDeadline =
+      deadlineMs !== undefined && !this.fastAdjudication
+        ? new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, deadlineMs - Date.now())))
+        : Promise.resolve();
+    await Promise.all([Promise.all(promises), waitForDeadline]);
     return allBuildOrders;
   }
 

--- a/src/game/router.ts
+++ b/src/game/router.ts
@@ -198,9 +198,12 @@ export function createGameRouter(lobbyManager: LobbyManager) {
       const fastAdjStr = config.fastAdjudication
         ? 'Enabled — the diplomacy phase ends as soon as all powers signal ready (via submitReady). Send your messages promptly; once all powers are ready, negotiations close immediately'
         : 'Disabled — the diplomacy phase always runs for the full duration regardless of readiness';
+      const yearLimitNote = config.endYear ? ` by **${config.endYear}** (the final year)` : '';
       const drawRules = config.allowDraws
-        ? `If no power reaches the victory threshold by **${config.endYear}** (the final year), the game ends in a draw among all surviving powers. Any power may propose a draw during a diplomacy phase. If all surviving powers propose a draw in the same phase, the game ends immediately as a shared draw.`
-        : `Draws are disabled. The game continues until a power reaches the victory threshold or the final year (**${config.endYear}**) is reached.`;
+        ? `If no power reaches the victory threshold${yearLimitNote}, the game ends in a draw among all surviving powers. Any power may propose a draw during a diplomacy phase. If all surviving powers propose a draw in the same phase, the game ends immediately as a shared draw.`
+        : config.endYear
+          ? `Draws are disabled. The game continues until a power reaches the victory threshold or the final year (**${config.endYear}**) is reached.`
+          : `Draws are disabled. The game continues until a power reaches the victory threshold.`;
       const rules = RULES_TEMPLATE.replace('{{VICTORY_THRESHOLD}}', String(config.victoryThreshold))
         .replace('{{START_YEAR}}', String(config.startYear))
         .replace('{{DRAW_RULES}}', drawRules)

--- a/src/game/router.ts
+++ b/src/game/router.ts
@@ -14,15 +14,35 @@ const RULES_TEMPLATE = readFileSync(new URL('../engine/RULES.md', import.meta.ur
 
 // ── Zod schemas ────────────────────────────────────────────────────────
 
-const powerEnum = z.enum([
-  Power.England,
-  Power.France,
-  Power.Germany,
-  Power.Italy,
-  Power.Austria,
-  Power.Russia,
-  Power.Turkey,
-]);
+const POWER_ABBREV: Record<string, Power> = {
+  eng: Power.England,
+  fra: Power.France,
+  ger: Power.Germany,
+  ita: Power.Italy,
+  aus: Power.Austria,
+  rus: Power.Russia,
+  tur: Power.Turkey,
+};
+
+const powerEnum = z
+  .enum([
+    Power.England,
+    Power.France,
+    Power.Germany,
+    Power.Italy,
+    Power.Austria,
+    Power.Russia,
+    Power.Turkey,
+    // Accept abbreviations too
+    'eng',
+    'fra',
+    'ger',
+    'ita',
+    'aus',
+    'rus',
+    'tur',
+  ])
+  .transform((val) => POWER_ABBREV[val] ?? val) as unknown as z.ZodType<Power>;
 
 const coastEnum = z.enum([Coast.North, Coast.South]);
 
@@ -232,8 +252,8 @@ export function createGameRouter(lobbyManager: LobbyManager) {
           return manager.getMessagesFor(identity.power as Power);
         }
       }
-      // Spectator: only global messages
-      return manager.getMessages().filter((m) => m.to === 'Global');
+      // Spectator: see all messages (private + global)
+      return manager.getMessages();
     }),
 
     getResult: publicProcedure.input(lobbyIdInput).query(({ input }) => {

--- a/src/game/router.ts
+++ b/src/game/router.ts
@@ -220,7 +220,9 @@ export function createGameRouter(lobbyManager: LobbyManager) {
         : 'Disabled — the diplomacy phase always runs for the full duration regardless of readiness';
       const yearLimitNote = config.endYear ? ` by **${config.endYear}** (the final year)` : '';
       const drawRules = config.allowDraws
-        ? `If no power reaches the victory threshold${yearLimitNote}, the game ends in a draw among all surviving powers. Any power may propose a draw during a diplomacy phase. If all surviving powers propose a draw in the same phase, the game ends immediately as a shared draw.`
+        ? config.endYear
+          ? `If no power reaches the victory threshold${yearLimitNote}, the game ends in a draw among all surviving powers. Any power may propose a draw during a diplomacy phase. If all surviving powers propose a draw in the same phase, the game ends immediately as a shared draw.`
+          : `The game continues until a power reaches the victory threshold. Any power may propose a draw during a diplomacy phase. If all surviving powers propose a draw in the same phase, the game ends immediately as a shared draw.`
         : config.endYear
           ? `Draws are disabled. The game continues until a power reaches the victory threshold or the final year (**${config.endYear}**) is reached.`
           : `Draws are disabled. The game continues until a power reaches the victory threshold.`;

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -106,7 +106,7 @@ function startServer(): void {
   const storage = new GameStorage(DB_PATH);
 
   // Load defaults from env vars + config file
-  const maxYears = parseInt(process.env.MAX_YEARS || '10');
+  const maxYears = process.env.MAX_YEARS ? parseInt(process.env.MAX_YEARS) : undefined;
   const phaseDelayMs = parseInt(process.env.PHASE_DELAY || '600000');
   const remoteTimeoutMs = parseInt(process.env.REMOTE_TIMEOUT || '0');
   const pressDelayMin = parseInt(process.env.PRESS_DELAY_MIN || '0');
@@ -150,7 +150,7 @@ function startServer(): void {
       runtime.allMessages.push(message);
       broadcastToLobby(id, { type: 'message', message }, (clientPower) => {
         if (message.to === 'Global') return true;
-        if (!clientPower) return false; // spectators don't see private press
+        if (!clientPower) return true; // spectators see private press
         if (message.to === clientPower) return true;
         if (message.from === clientPower) return true;
         if (Array.isArray(message.to) && message.to.includes(clientPower)) return true;
@@ -183,7 +183,7 @@ function startServer(): void {
               ...snapshot,
               messages: snapshot.messages.filter((msg) => {
                 if (msg.to === 'Global') return true;
-                if (!clientPower) return false;
+                if (!clientPower) return true; // spectators see all press
                 return (
                   msg.to === clientPower ||
                   msg.from === clientPower ||
@@ -348,7 +348,7 @@ function startServer(): void {
       ...s,
       messages: s.messages.filter((msg) => {
         if (msg.to === 'Global') return true;
-        if (!clientPower) return false;
+        if (!clientPower) return true; // spectators see all press
         return (
           msg.to === clientPower ||
           msg.from === clientPower ||

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -214,7 +214,13 @@ function startServer(): void {
             agentCfg.provider === 'anthropic'
               ? new AnthropicClient(llmConfig)
               : new OpenAICompatibleClient(llmConfig);
-          const handle = await connectToolAgent(agentClient, llmClient, power, id);
+          const handle = await connectToolAgent(
+            agentClient,
+            llmClient,
+            power,
+            id,
+            process.env.PLAN_DIR,
+          );
           runtime.agentConnections.push(handle);
           logger.info(
             `  ${power}: LLM tool-calling (${agentCfg.provider ?? 'openai'} / ${toLLMClientConfig(agentCfg).model})`,


### PR DESCRIPTION
## Summary

Major improvements to LLM agent gameplay quality, driven by iterative integration testing with Ollama-powered agents.

- Add auto-computed strategic summary (power rankings, neutral SCs, neighbor threats)
- Add persistent plan memory across phases (GOAL/ALLIES/THREATS/ORDERS/REFLECTION)
- Fix Hold-spam and build blindness through prompt improvements
- Support unlimited game length (canonical Diplomacy rules)
- Address all CodeRabbit review feedback from PR #59

## Key Changes

### Agent Context System (`src/agent/llm/prompts.ts`)
- **`buildStrategicSummary()`** — deterministic computation of power rankings, neutral SCs, neighbor detection, position summary. Zero LLM cost.
- **`extractPlanBlock()`** — extracts `` ```plan `` blocks from LLM responses for cross-phase persistence
- **Plan injection** — previous phase's plan shown in turn prompt with accountability ("did you follow through on ORDERS?")
- **Structured plan format** — GOAL, ALLIES, THREATS, ORDERS (pre-committed moves), REFLECTION (learning from results)

### Prompt Improvements (`src/agent/llm/prompts.ts`)
- Anti-Hold strategy section ("NEVER hold all units", campaign momentum)
- Phase-specific neutral SC targeting (identifies reachable unowned SCs)
- Schema-based build instructions with open home center detection
- Scoped submit mandate to actionable phases (not Diplomacy phase)
- Waive and multi-coast build guidance

### Plan Persistence (`src/agent/llm/tool-agent.ts`)
- `planDir` parameter on `connectToolAgent()` (optional, disabled when unset)
- File-based persistence: `{planDir}/{lobbyId}/{power}-plan.md`
- Read before each phase, extract from primary tool loop response
- All call sites updated: `run.ts`, `run-with-notes.ts`, `server.ts`

### Engine (`src/game/manager.ts`, `src/engine/types.ts`)
- `maxYears` defaults to `undefined` (no year limit — canonical Diplomacy rules)
- Game runs until victory (18 SCs) or unanimous draw vote

### Bug Fixes (from PR #59 review)
- Return accumulated text on max iterations (was returning empty string)
- Retry submit even when model called `ready()` prematurely
- Revert lobby timeout default to 0 (indefinite)
- Fix phase label in `formatMessage` for temporal context
- Prettier formatting, config model consistency, SKILL.md fixes

## Integration Test Results

| Metric | Before (qwen2.5:14b) | After (qwen3.5:9b + context) |
|--------|----------------------|------------------------------|
| SC changes in Year 1 | 1 | 4 |
| Build success rate | 0/15+ winters | 4/4 (100%) |
| Active powers in Year 1 | 1 of 7 | 6-7 of 7 |
| Hold order rate | ~80% | ~20% |
| Plan persistence | N/A | Working (GOAL/ALLIES/THREATS/ORDERS/REFLECTION) |

## Test plan
- [x] 319 unit tests pass (`yarn test`)
- [x] Build passes (`yarn build`)
- [x] Lint passes (`yarn lint`)
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Multiple integration games run with Ollama (qwen2.5:14b and qwen3.5:9b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents persist and reuse markdown plans; turn prompts include richer strategic context and nearby/target guidance.
  * Messaging supports power abbreviations, multiple recipients, and global sends.
  * Games may run indefinitely when no year limit is set.

* **Configuration**
  * Default AI model upgraded to qwen3:8b.
  * New env vars for LLM concurrency and request timeouts (LLM_CONCURRENCY, LLM_REQUEST_TIMEOUT_MS); LLM requests use longer-lived connections.

* **Tests**
  * Added tests for plan extraction, strategic summaries, semaphore concurrency, and related utilities.

* **Documentation**
  * README and setup docs updated with concurrency, timeout, and monitoring guidance; spectator message visibility expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->