### PR TITLE
fix: spectator UI broken — WebSocket missing map field

### DIFF
--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -15,6 +15,7 @@ import { OpenAICompatibleClient } from '../agent/llm/llm-client';
 import { connectToolAgent } from '../agent/llm/tool-agent';
 import { connectRandomAgent } from '../agent/random-agent';
 import { createGameClient } from '../agent/remote/client';
+import { buildMapState } from '../engine/map-state';
 import { Message, Power } from '../engine/types';
 import { describeProcedure } from '../game/describe';
 import { LobbyManager } from '../game/lobby-manager';
@@ -43,8 +44,9 @@ const ALL_POWERS: Power[] = [
 
 function serializeState(state: import('../engine/types.js').GameState) {
   return {
-    ...state,
-    supplyCenters: Object.fromEntries(state.supplyCenters),
+    phase: state.phase,
+    map: buildMapState(state.units, state.supplyCenters),
+    retreatSituations: state.retreatSituations,
   };
 }
 


### PR DESCRIPTION
## Summary
- The WebSocket `serializeState` in `server.ts` was spreading raw `GameState` (which has `units` and `supplyCenters` but no `map` field), while the spectator UI client expects `gameState.map: Record<string, ProvinceState>`
- The tRPC router's `serializeState` already correctly called `buildMapState()` — the WebSocket path was missed
- Fixed by calling `buildMapState(state.units, state.supplyCenters)` in the WebSocket serialization, matching the client's expected shape

## Test plan
- [x] `tsc --noEmit` passes
- [x] `yarn build` passes
- [x] All 311 tests pass
- [x] Spin up a game with `yarn play:random` and verify the spectator UI at `http://localhost:3000` shows province colors, units, arrows, and SC summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal game state serialization to use a more structured approach, improving how game phases, map data, and retreat information are handled and preserved during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->